### PR TITLE
Fixed regression of cloudfront config change.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -119,10 +119,10 @@ const aws = {
   s3: {
     baseUrl: 'https://s3.amazonaws.com',
     staticResourceBucket: process.env.STORAGE_S3_STATIC_RESOURCE_BUCKET ?? 'default',
-    region: process.env.STORAGE_S3_REGION ?? 'us-east-1',
-    cloudfront: {
-      domain: process.env.STORAGE_S3_CLOUDFRONT_DOMAIN ?? ''
-    }
+    region: process.env.STORAGE_S3_REGION ?? 'us-east-1'
+  },
+  cloudfront: {
+    domain: process.env.STORAGE_CLOUDFRONT_DOMAIN ?? ''
   },
   sms: {
     accessKeyId: process.env.AWS_SMS_ACCESS_KEY_ID ?? '',

--- a/src/hooks/convert-video.ts
+++ b/src/hooks/convert-video.ts
@@ -254,7 +254,7 @@ export default async (context: any): Promise<void> => {
           const mimetype = mimetypeDict[extension]
 
           localContext.data.url = 'https://' +
-            path.join(config.aws.s3.cloudfront.domain, key)
+            path.join(config.aws.cloudfront.domain, key)
           localContext.data.mimeType = mimetype
 
           localContext.params.mimeType = mimetype

--- a/src/hooks/reformat-upload-result.ts
+++ b/src/hooks/reformat-upload-result.ts
@@ -9,7 +9,7 @@ export default (options = {}): Hook => {
 
     delete context.result.uri
 
-    const url = 'https://' + config.aws.s3.cloudfront.domain + '/' +
+    const url = 'https://' + config.aws.cloudfront.domain + '/' +
       (context.result.id as string || context.data.id as string)
 
     context.data.url = url

--- a/src/hooks/remove-related-resources.ts
+++ b/src/hooks/remove-related-resources.ts
@@ -23,7 +23,7 @@ export default (options = {}): Hook => {
       const storageRemovePromise = new Promise((resolve, reject) => {
         if (staticResource.url && staticResource.url.length > 0) {
           const key = staticResource.url.replace('https://' +
-            config.aws.s3.cloudfront.domain + '/', '')
+            config.aws.cloudfront.domain + '/', '')
 
           if (storage === undefined) {
             reject(new Error('Storage is undefined'))

--- a/src/hooks/replace-thumbnail-link.ts
+++ b/src/hooks/replace-thumbnail-link.ts
@@ -32,7 +32,7 @@ export default (options = {}): Hook => {
         const contextClone = _.cloneDeep(context)
         const result = await uploadThumbnailLinkHook()(contextClone)
         data.metadata.thumbnail_url = (result as any).params.thumbnailUrl
-          .replace('s3.amazonaws.com/' + bucketName, config.aws.s3.cloudfront.domain)
+          .replace('s3.amazonaws.com/' + bucketName, config.aws.cloudfront.domain)
       }
     }
 

--- a/src/hooks/upload-thumbnail-link.ts
+++ b/src/hooks/upload-thumbnail-link.ts
@@ -34,7 +34,7 @@ export default (options = {}): Hook => {
       const parsedMetadata = JSON.parse(parent.metadata)
       parsedMetadata.thumbnail_url = uploadResult.url
         .replace('s3.amazonaws.com/' + (config.aws.s3.staticResourceBucket),
-          config.aws.s3.cloudfront.domain)
+          config.aws.cloudfront.domain)
       await app.services['static-resource'].patch(id, {
         metadata: parsedMetadata
       })


### PR DESCRIPTION
Cloudfront config had been moved from config.aws.s3 to config.aws.
Cloudfront is not inherently a part of S3.
This got regressed in the config update PR.